### PR TITLE
strict_types is also affected

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Promotion to TypeError: next major version, i.e. PHP 9.0.
 
  - Manual casting to string will not emit a deprecation diagnostic.
  - String to boolean implicit coercions are not affected.
- - Strict type behaviour is unaffected.
  - Coercion from bool to int
  - Coercion from bool to float
  - `printf()` family of functions


### PR DESCRIPTION
E.g. https://3v4l.org/oaRkv

String concatenation with bool is currently fine, even with `strict_types`. There are other cases too.