### PR TITLE
Also deprecate printf

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following operations will now emit an E_DEPRECATED if a boolean is used:
  - Assignment to a typed property of type `string` in coercive typing mode
  - Argument for a parameter of type `string` for both internal and userland functions in coercive typing mode
  - Returning such a value for userland functions declared with a return type of `string` in coercive typing mode
- 
+ - `printf()` family of functions 
 
 ## Proposed PHP Version
 
@@ -62,7 +62,6 @@ Promotion to TypeError: next major version, i.e. PHP 9.0.
  - Strict type behaviour is unaffected.
  - Coercion from bool to int
  - Coercion from bool to float
- - `printf()` family of functions
 
 ## Future scope
 


### PR DESCRIPTION
I actually now thing we should deprecate absolutely all implicit coercion of bool to string, this includes `printf`. `printf` uses the same function for coercion as the rest of the engine so it does trigger a deprecation. We can manually exclude `printf` and other functions but it makes me think where we should stop. Ultimately, I think using `bool`s in `printf` has the same issues as everywhere else.

Let me know what you think.